### PR TITLE
Accept $1$ salt.

### DIFF
--- a/lib/apache-md5.js
+++ b/lib/apache-md5.js
@@ -56,9 +56,17 @@ var MD5 = {
         return epass;
     },
     encrypt: function(password, salt) {
+        var magic = '';
+
+        if (salt.split('$')[1] === '1') {
+            magic = '$1$'
+        } else {
+            magic = '$apr1$'
+        }
+
         salt = MD5.getSalt(salt);
 
-        var ctx = password + "$apr1$" + salt;
+        var ctx = password + magic + salt;
         var final = crypto.createHash('md5').update(password + salt + password).digest("binary");
 
         for (var pl = password.length; pl > 0; pl -= 16) {
@@ -98,7 +106,7 @@ var MD5 = {
             final = crypto.createHash('md5').update(ctxl).digest("binary");
         }
 
-        return "$apr1$" + salt + "$" + MD5.getPassword(final);
+        return magic + salt + "$" + MD5.getPassword(final);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "apache-md5",
 	"description": "Node.js module for Apache style password encryption using md5.",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"author": "Gevorg Harutyunyan (http://github.com/gevorg)",
 	"maintainers": [
 		{


### PR DESCRIPTION
I have added the option to use the shorted '$1$' instead of '$apr1$' for the magic portion of the salt, as compliant with the [apache-crypt](https://github.com/gevorg/apache-crypt) module.
