### PR TITLE
fix(crypto): update now assumed utf8 by default

### DIFF
--- a/lib/apache-md5.js
+++ b/lib/apache-md5.js
@@ -1,5 +1,7 @@
 // Crypto module import.
 var crypto = require('crypto');
+var isNode10 = !!process.version.match(/^v0.10/);
+var encoding = isNode10 ? null : 'ascii';
 
 var MD5 = {
     itoa64: './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
@@ -17,7 +19,7 @@ var MD5 = {
         var salt = '';
 
         if (inputSalt) { // Remove $apr1$ token and extract salt.
-            salt = inputSalt.split("$")[2];
+            salt = inputSalt.split('$')[2];
         } else {
             while(salt.length < 8) { // Random 8 chars.
                 var rchIndex = Math.floor((Math.random() * 64));
@@ -67,7 +69,7 @@ var MD5 = {
         salt = MD5.getSalt(salt);
 
         var ctx = password + magic + salt;
-        var final = crypto.createHash('md5').update(password + salt + password, 'ascii').digest("binary");
+        var final = crypto.createHash('md5').update(password + salt + password, encoding).digest('binary');
 
         for (var pl = password.length; pl > 0; pl -= 16) {
             ctx += final.substr(0, (pl > 16) ? 16 : pl);
@@ -81,7 +83,7 @@ var MD5 = {
             }
         }
 
-        final = crypto.createHash('md5').update(ctx, 'ascii').digest("binary");
+        final = crypto.createHash('md5').update(ctx, encoding).digest('binary');
 
         // 1000 loop.
         for (var i = 0; i < 1000; ++i) { // Weird stuff.
@@ -103,10 +105,10 @@ var MD5 = {
                 ctxl += password;
             }
             // Final assignment after each loop.
-            final = crypto.createHash('md5').update(ctxl, 'ascii').digest("binary");
+            final = crypto.createHash('md5').update(ctxl, encoding).digest('binary');
         }
 
-        return magic + salt + "$" + MD5.getPassword(final);
+        return magic + salt + '$' + MD5.getPassword(final);
     }
 };
 

--- a/lib/apache-md5.js
+++ b/lib/apache-md5.js
@@ -67,7 +67,7 @@ var MD5 = {
         salt = MD5.getSalt(salt);
 
         var ctx = password + magic + salt;
-        var final = crypto.createHash('md5').update(password + salt + password).digest("binary");
+        var final = crypto.createHash('md5').update(password + salt + password, 'ascii').digest("binary");
 
         for (var pl = password.length; pl > 0; pl -= 16) {
             ctx += final.substr(0, (pl > 16) ? 16 : pl);
@@ -81,7 +81,7 @@ var MD5 = {
             }
         }
 
-        final = crypto.createHash('md5').update(ctx).digest("binary");
+        final = crypto.createHash('md5').update(ctx, 'ascii').digest("binary");
 
         // 1000 loop.
         for (var i = 0; i < 1000; ++i) { // Weird stuff.
@@ -103,7 +103,7 @@ var MD5 = {
                 ctxl += password;
             }
             // Final assignment after each loop.
-            final = crypto.createHash('md5').update(ctxl).digest("binary");
+            final = crypto.createHash('md5').update(ctxl, 'ascii').digest("binary");
         }
 
         return magic + salt + "$" + MD5.getPassword(final);


### PR DESCRIPTION
This module depended on the fact that node used to assume that data
passed to a crypto hasher's `update` method was encoded as latin-1
where it now defaults to utf8 in node 6+. This fix restores normal
behavior in a backward compatible way
